### PR TITLE
Change GitHub class name

### DIFF
--- a/apple/not-github/not-github/GitHubParser.swift
+++ b/apple/not-github/not-github/GitHubParser.swift
@@ -16,7 +16,7 @@ enum GitHubParser {
             let url = URL(string: "https://github.com/\(username)")!
             let html = try String(contentsOf: url)
             let doc = try SwiftSoup.parse(html)
-            let dayElements = try doc.getElementsByClass("day")
+            let dayElements = try doc.getElementsByClass("ContributionCalendar-day")
             
             let developmentDays = dayElements.compactMap { element -> DevelopmentDay? in
                 guard


### PR DESCRIPTION
Motive:
Github class name for the day class in `not-github` project is wrong. Thus, the app is not working as expected.

References:
[Tutorial](https://www.youtube.com/watch?v=uZF5DiMshFY)
